### PR TITLE
Handle exceptions gracefully in TriggerLock

### DIFF
--- a/lib/sqeduler/trigger_lock.rb
+++ b/lib/sqeduler/trigger_lock.rb
@@ -15,6 +15,8 @@ module Sqeduler
       # - return true if already acquired
       # - refresh the lock if already acquired
       refresh || super
+    rescue
+      false
     end
   end
 end

--- a/spec/trigger_lock_spec.rb
+++ b/spec/trigger_lock_spec.rb
@@ -76,5 +76,11 @@ RSpec.describe Sqeduler::TriggerLock do
       expect(trigger_lock_2.locked?).to be(true)
       expect(trigger_lock_1.unlock).to be(false)
     end
+
+    it "should not acquire the lock if there is an error" do
+      allow(trigger_lock_1).to receive(:refresh_lock).and_raise("boom")
+      expect(trigger_lock_1.lock).to be false
+      expect(trigger_lock_1.locked?).to be false
+    end
   end
 end


### PR DESCRIPTION
looks like [redis-rb](https://github.com/redis/redis-rb) just raises `RuntimeError`: https://github.com/redis/redis-rb/blob/98e3e7a516fc9b4609bc8ab482605f835a4de621/lib/redis/errors.rb#L3