### PR TITLE
Update syntax to adhere to rubocop 0.36.0

### DIFF
--- a/lib/sqeduler/redis_scripts.rb
+++ b/lib/sqeduler/redis_scripts.rb
@@ -23,12 +23,13 @@ module Sqeduler
     def load_sha(redis, script_name)
       @redis_sha_cache ||= {}
       @redis_sha_cache[script_name] ||= begin
-        script = if script_name == :refresh
-          refresh_lock_script
-        elsif script_name == :release
-          release_lock_script
-        else
-          fail "No script for #{script_name}"
+        script = case script_name
+                 when :refresh
+                   refresh_lock_script
+                 when :release
+                   release_lock_script
+                 else
+                   fail "No script for #{script_name}"
         end
         # strip leading whitespace of 8 characters
         redis.script(:load, script.gsub(/^ {8}/, ""))

--- a/lib/sqeduler/service.rb
+++ b/lib/sqeduler/service.rb
@@ -5,7 +5,7 @@ module Sqeduler
   # Singleton class for configuring this Gem.
   class Service
     SCHEDULER_TIMEOUT = 60
-    MINIMUM_REDIS_VERSION = "2.6.12"
+    MINIMUM_REDIS_VERSION = "2.6.12".freeze
 
     class << self
       attr_accessor :config
@@ -104,11 +104,8 @@ module Sqeduler
 
       def logger
         return config.logger if config.logger
-        if defined?(Rails)
-          Rails.logger
-        else
-          fail ArgumentError, "No logger provided and Rails.logger cannot be inferred"
-        end
+        return Rails.logger if defined?(Rails)
+        fail ArgumentError, "No logger provided and Rails.logger cannot be inferred"
       end
     end
   end

--- a/lib/sqeduler/version.rb
+++ b/lib/sqeduler/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module Sqeduler
-  VERSION = "0.2.2"
+  VERSION = "0.2.2".freeze
 end

--- a/lib/sqeduler/worker/kill_switch.rb
+++ b/lib/sqeduler/worker/kill_switch.rb
@@ -3,7 +3,7 @@ module Sqeduler
   module Worker
     # Uses Redis hashes to enabled and disable workers across multiple hosts.
     module KillSwitch
-      SIDEKIQ_DISABLED_WORKERS = "sidekiq.disabled-workers"
+      SIDEKIQ_DISABLED_WORKERS = "sidekiq.disabled-workers".freeze
 
       def self.prepended(base)
         if base.ancestors.include?(Sqeduler::Worker::Callbacks)

--- a/spec/fixtures/env.rb
+++ b/spec/fixtures/env.rb
@@ -1,15 +1,14 @@
 require "sqeduler"
 require_relative "fake_worker"
 
-REDIS_CONFIG = {
-  :host => "localhost",
-  :db => 1,
-  :namespace => "sqeduler-tests"
-}
 Sidekiq.logger = Logger.new(STDOUT).tap { |l| l.level = Logger::DEBUG }
 
 Sqeduler::Service.config = Sqeduler::Config.new(
-  :redis_hash => REDIS_CONFIG,
+  :redis_hash => {
+    :host => "localhost",
+    :db => 1,
+    :namespace => "sqeduler-tests"
+  },
   :logger => Sidekiq.logger,
   :schedule_path => File.expand_path(File.dirname(__FILE__)) + "/schedule.yaml",
   :on_server_start => proc do |_config|

--- a/spec/fixtures/fake_worker.rb
+++ b/spec/fixtures/fake_worker.rb
@@ -1,12 +1,12 @@
 # encoding: utf-8
 # Sample worker for specs
 class FakeWorker
-  JOB_RUN_PATH =            "/tmp/job_run"
-  JOB_BEFORE_START_PATH =   "/tmp/job_before_start"
-  JOB_SUCCESS_PATH =        "/tmp/job_success"
-  JOB_FAILURE_PATH =        "/tmp/job_failure"
-  JOB_LOCK_FAILURE_PATH =   "/tmp/lock_failure"
-  SCHEDULE_COLLISION_PATH = "/tmp/schedule_collision"
+  JOB_RUN_PATH =            "/tmp/job_run".freeze
+  JOB_BEFORE_START_PATH =   "/tmp/job_before_start".freeze
+  JOB_SUCCESS_PATH =        "/tmp/job_success".freeze
+  JOB_FAILURE_PATH =        "/tmp/job_failure".freeze
+  JOB_LOCK_FAILURE_PATH =   "/tmp/lock_failure".freeze
+  SCHEDULE_COLLISION_PATH = "/tmp/schedule_collision".freeze
   include Sidekiq::Worker
   include Sqeduler::Worker::Everything
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,11 +4,7 @@ require "rspec"
 require "sqeduler"
 require "timecop"
 
-REDIS_CONFIG = {
-  :host => "localhost",
-  :db => 1
-}
-TEST_REDIS = Redis.new(REDIS_CONFIG)
+TEST_REDIS = Redis.new(:host => "localhost", :db => 1)
 
 Timecop.safe_mode = true
 
@@ -16,6 +12,7 @@ RSpec.configure do |config|
   config.before(:each) do
     TEST_REDIS.flushdb
     Sqeduler::Service.config = nil
+    REDIS_CONFIG = { :host => "localhost", :db => 1 }.clone
   end
   config.disable_monkey_patching!
 end

--- a/sqeduler.gemspec
+++ b/sqeduler.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry", "~> 0"
   gem.add_development_dependency "rake", "~> 10"
   gem.add_development_dependency "rspec", "~> 3.3"
-  gem.add_development_dependency "rubocop", "~> 0.24"
+  gem.add_development_dependency "rubocop", "~> 0.36.0"
   gem.add_development_dependency "timecop", "~> 0"
   gem.add_development_dependency "yard", "~> 0"
 end


### PR DESCRIPTION
Right now, the builds are failing on Travis CI because it's using the
latest version of rubocop which has updated a few things.

```
Offenses:
lib/sqeduler/redis_scripts.rb:28:9: C: Use a guard clause instead of wrapping the code inside a conditional expression.
        elsif script_name == :release
        ^^^^^
lib/sqeduler/service.rb:8:29: C: Freeze mutable objects assigned to constants.
    MINIMUM_REDIS_VERSION = "2.6.12"
                            ^^^^^^^^
lib/sqeduler/service.rb:107:9: C: Use a guard clause instead of wrapping the code inside a conditional expression.
        if defined?(Rails)
        ^^
lib/sqeduler/version.rb:3:13: C: Freeze mutable objects assigned to constants.
  VERSION = "0.2.2"
            ^^^^^^^
lib/sqeduler/worker/kill_switch.rb:6:34: C: Freeze mutable objects assigned to constants.
      SIDEKIQ_DISABLED_WORKERS = "sidekiq.disabled-workers"
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/fixtures/env.rb:4:16: C: Freeze mutable objects assigned to constants.
REDIS_CONFIG = {
               ^
spec/fixtures/fake_worker.rb:4:29: C: Freeze mutable objects assigned to constants.
  JOB_RUN_PATH =            "/tmp/job_run"
                            ^^^^^^^^^^^^^^
spec/fixtures/fake_worker.rb:5:29: C: Freeze mutable objects assigned to constants.
  JOB_BEFORE_START_PATH =   "/tmp/job_before_start"
                            ^^^^^^^^^^^^^^^^^^^^^^^
spec/fixtures/fake_worker.rb:6:29: C: Freeze mutable objects assigned to constants.
  JOB_SUCCESS_PATH =        "/tmp/job_success"
                            ^^^^^^^^^^^^^^^^^^
spec/fixtures/fake_worker.rb:7:29: C: Freeze mutable objects assigned to constants.
  JOB_FAILURE_PATH =        "/tmp/job_failure"
                            ^^^^^^^^^^^^^^^^^^
spec/fixtures/fake_worker.rb:8:29: C: Freeze mutable objects assigned to constants.
  JOB_LOCK_FAILURE_PATH =   "/tmp/lock_failure"
                            ^^^^^^^^^^^^^^^^^^^
spec/fixtures/fake_worker.rb:9:29: C: Freeze mutable objects assigned to constants.
  SCHEDULE_COLLISION_PATH = "/tmp/schedule_collision"
                            ^^^^^^^^^^^^^^^^^^^^^^^^^
spec/spec_helper.rb:7:16: C: Freeze mutable objects assigned to constants.
REDIS_CONFIG = {
               ^
27 files inspected, 13 offenses detected
RuboCop failed!
```

@jaredjenkins @ggilder 