### PR TITLE
Add ability to use provided ConnectionPool

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 0.3.4 / 2016-03-28
+
+* Add ability to use a client-provided connection pool rather than creating one
+
 ### 0.3.3 / 2016-03-25
 
 * Fixed lock refresher not calling `redis_pool` properly so it wouldn't actually run
@@ -5,7 +9,7 @@
 ### 0.3.2 / 2016-03-10
 
 * Fixed lock refresher failing to lock properly for exclusive runs
-* Added debug logs for lock refresher 
+* Added debug logs for lock refresher
 
 ### 0.3.1 / 2016-02-17
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Sqeduler::Service.config = config
 Sqeduler::Service.start
 ```
 
+You can also pass in your own `ConnectionPool` instance as `config.redis_pool` rather than providing configuration in `redis_hash`. If you do so, it's recommended to use a `Redis::Namespace` so that the keys sqeduler sets are namespaced uniquely.
+
 See documentation for [Sidekiq::Scheduler](https://github.com/Moove-it/sidekiq-scheduler#scheduled-jobs-recurring-jobs)
 for specifics on how to construct your schedule YAML file.
 

--- a/lib/sqeduler/config.rb
+++ b/lib/sqeduler/config.rb
@@ -2,11 +2,12 @@
 module Sqeduler
   # Simple config for Sqeduler::Service
   class Config
-    attr_accessor :logger, :redis_hash, :schedule_path,
+    attr_accessor :logger, :redis_hash, :redis_pool, :schedule_path,
                   :on_server_start, :on_client_start, :maintain_locks
 
     def initialize(opts = {})
       self.redis_hash = opts[:redis_hash]
+      self.redis_pool = opts[:redis_pool]
       self.schedule_path = opts[:schedule_path]
       self.on_server_start = opts[:on_server_start]
       self.on_client_start = opts[:on_client_start]

--- a/lib/sqeduler/service.rb
+++ b/lib/sqeduler/service.rb
@@ -95,12 +95,18 @@ module Sqeduler
       # separate from Sidekiq's so that we don't saturate the client and server connection
       # pools.
       def redis_pool
-        @redis_pool ||= begin
+        @redis_pool ||= config_redis_pool
+      end
+
+      def config_redis_pool
+        redis_pool = if config.redis_pool
+          config.redis_pool
+        else
           redis = { :namespace => "sqeduler" }.merge(config.redis_hash)
-          ::Sidekiq::RedisConnection.create(redis).tap do |redis_pool|
-            verify_redis_pool(redis_pool)
-          end
+          ::Sidekiq::RedisConnection.create(redis)
         end
+        verify_redis_pool(redis_pool)
+        redis_pool
       end
 
       def logger

--- a/lib/sqeduler/version.rb
+++ b/lib/sqeduler/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module Sqeduler
-  VERSION = "0.3.3".freeze
+  VERSION = "0.3.4".freeze
 end


### PR DESCRIPTION
This is sort of a workaround to allow me to use a different Redis adapter, but seems generally worthwhile too.

@zanker @tarcieri @jkingdon 