### PR TITLE
Call #script directly on the Redis connection

### DIFF
--- a/lib/sqeduler/redis_scripts.rb
+++ b/lib/sqeduler/redis_scripts.rb
@@ -32,7 +32,7 @@ module Sqeduler
                    raise "No script for #{script_name}"
         end
         # strip leading whitespace of 8 characters
-        redis.script(:load, script.gsub(/^ {8}/, ""))
+        redis.redis.script(:load, script.gsub(/^ {8}/, ""))
       end
     end
 


### PR DESCRIPTION
Redis::Namespace has deprecated use of #script, which is directly forwarded to the underlying connection anyway.

Without this change, we get this deprecation warning:

    Passing 'script' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0