### PR TITLE
Yard gem update (vuln fix)

### DIFF
--- a/sqeduler.gemspec
+++ b/sqeduler.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec", "~> 3.3"
   gem.add_development_dependency "rubocop", "~> 0.39.0"
   gem.add_development_dependency "timecop", "~> 0"
-  gem.add_development_dependency "yard", "~> 0"
+  gem.add_development_dependency "yard", "~> 0.9.11"
 end


### PR DESCRIPTION
`yard` < `0.9.11` has a high sev. vuln, so let's fix it.